### PR TITLE
S3にアップロードされた動画のURLを、フロントエンドのreactに送りたい

### DIFF
--- a/src/components/organisms/ContentVideoCard.tsx
+++ b/src/components/organisms/ContentVideoCard.tsx
@@ -19,7 +19,7 @@ export const ContentVideoCard = (props: ContentVideo) => {
     number,
     title,
     description,
-    youtube_url,
+    thumbnail,
     liked,
   } = props;
   const {setLikedState} = useState(liked);
@@ -38,8 +38,6 @@ export const ContentVideoCard = (props: ContentVideo) => {
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
                   {description}
-                  Lizards are a widespread group of squamate reptiles, with over 6,000
-                  species, ranging across all continents except Antarctica
                 </Typography>
               </CardContent>
               <CardActions>
@@ -52,7 +50,7 @@ export const ContentVideoCard = (props: ContentVideo) => {
               <Link to={`/contents_videos/${id}`} state={{id : id}}>
                 このコンテンツで撮影チャレンジ！
               </Link>
-              <img src={`${process.env.PUBLIC_URL}/thumbnail/${youtube_url}`} width="100%" />
+              <img src={`${process.env.PUBLIC_URL}/thumbnail/${thumbnail}`} width="100%" />
             </Card>
           </Grid>
           <Grid xs={0} lg={2}></Grid>

--- a/src/components/organisms/ContentVideoCard.tsx
+++ b/src/components/organisms/ContentVideoCard.tsx
@@ -24,12 +24,6 @@ export const ContentVideoCard = (props: ContentVideo) => {
   } = props;
   const {setLikedState} = useState(liked);
 
-  const VideoShowstate = {
-    id: props.id,
-    title: props.title,
-    youtube_url: props.youtube_url,
-};
-
   return (
 
     <div className="card" key={id}>
@@ -55,11 +49,9 @@ export const ContentVideoCard = (props: ContentVideo) => {
                     <LikeButton id={id} changeLike={setLikedState} />
                   )}
               </CardActions>
-              <Link to={{
-                pathname: `/contents_videos/${id}`,
-                state: VideoShowstate,
-              }}
-              >このコンテンツで撮影チャレンジ！</Link>
+              <Link to={`/contents_videos/${id}`} state={{id : id}}>
+                このコンテンツで撮影チャレンジ！
+              </Link>
               <img src={`${process.env.PUBLIC_URL}/thumbnail/${youtube_url}`} width="100%" />
             </Card>
           </Grid>

--- a/src/components/organisms/ContentVideoShowCard.tsx
+++ b/src/components/organisms/ContentVideoShowCard.tsx
@@ -1,0 +1,44 @@
+// @ts-nocheck
+//import { useState } from 'react';
+//import YouTube from 'react-youtube';
+//import { Link } from 'react-router-dom';
+//import { LikeButton } from "components/molecules/LikeButton";
+//import { UnlikeButton } from "components/molecules/UnlikeButton";
+import type { ContentVideo } from "types/contentvideo";
+
+//import Box from '@mui/material/Box';
+import Card from "@material-ui/core/Card";
+//import CardActions from '@mui/material/CardActions';
+import CardContent from '@mui/material/CardContent';
+import Typography from '@mui/material/Typography';
+//import Grid from '@mui/material/Unstable_Grid2';
+
+export const ContentVideoShowCard = (props: ContentVideo) => {
+  const {
+    id,
+    //number,
+    title,
+    //description,
+    youtube_url,
+    //liked,
+  } = props;
+//  const {setLikedState} = useState(liked);
+
+  return (
+    <div>
+    <h1>個別記事 {id}</h1>
+    <Card>
+        <CardContent>
+          <Typography gutterBottom variant="h5" component="div">
+          {title}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            Lizards are a widespread group of squamate reptiles, with over 6,000
+            species, ranging across all continents except Antarctica
+          </Typography>
+        </CardContent>
+        <img src={`${process.env.PUBLIC_URL}/thumbnail/${youtube_url}`} width="100%" />
+    </Card>
+    </div>
+  )
+}

--- a/src/components/organisms/ContentVideosList.tsx
+++ b/src/components/organisms/ContentVideosList.tsx
@@ -71,7 +71,7 @@ const ContentVideos = ({ }) => {
             number = {content_video.attributes.number}
             title = {content_video.attributes.title}
             description = {content_video.attributes.description}
-            youtube_url = {content_video.attributes.youtube_url}
+            thumbnail = {content_video.attributes.thumbnail}
             liked = {content_video.attributes.liked}
           />
         ))}

--- a/src/components/organisms/ContentVideosList.tsx
+++ b/src/components/organisms/ContentVideosList.tsx
@@ -38,7 +38,6 @@ const ContentVideos = ({ }) => {
         console.error(error.response.data);
       });
       setContentVideos(res.data.data);
-      console.log(contentVideos)
       }
     );
 
@@ -59,8 +58,8 @@ const ContentVideos = ({ }) => {
           コンテンツ動画がありません
         </p>
       </div>
-      )
-    }
+    )
+  }
 
   return (
       <div className="container">

--- a/src/components/pages/ContentVideoShow.tsx
+++ b/src/components/pages/ContentVideoShow.tsx
@@ -40,11 +40,9 @@ const GetContentVideo = ({}) => {
         console.error(error.response.data);
       });
       setContentVideo(res.data.data);
-      console.log(res.data.data)
-      console.log(contentVideo)
     }
   );
-  console.log(contentVideo)
+
   if (queryLoading) {
     return (
       <div style={{ textAlign: 'center', marginTop: '150px' }}>

--- a/src/components/pages/ContentVideoShow.tsx
+++ b/src/components/pages/ContentVideoShow.tsx
@@ -1,36 +1,89 @@
-import { useParams } from 'react-router-dom'
-import { useLocation } from "react-router";
+// @ts-nocheck
+import { useState } from 'react';
+import axios from 'axios';
+import { REST_API_URL } from 'urls/index';
+import type { ContentVideo } from "types/contentvideo";
+import { useLocation } from "react-router-dom";
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+} from 'react-query';
 import Card from "@material-ui/core/Card";
 import CardActions from '@mui/material/CardActions';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
 import { idText } from 'typescript';
 
+interface State {
+  id: number;
+}
 
-export const ContentVideoShow = () => {
+const GetContentVideo = () => {
+  const [contentVideo, setContentVideo ] = useState<ContentVideo[]>([]);
+  const location = useLocation();
+  const { id } = location.state as State;
+  let { isLoading: queryLoading } = useQuery(['content_videos'],
+    async () => {
+  //const { state } = useLocation();
+  //const { id, title, youtube_url } = state;
 
-  const { state } = useLocation();
-  const { id, title, youtube_url } = state;
+    /** GETの処理 */
+    const res = await axios
+      .get<ContentVideo[]>(`${REST_API_URL}/user/content_videos/${id}`,{
+        headers: {
+          'Content-Type': 'application/json',
+        },
+      })
+      .catch((error) => {
+        console.error(error.response.data);
+      });
+      setContentVideo(res.data.data);
+      console.log(contentVideo)
+    }
+  );
+
+  if (queryLoading) {
+    return (
+      <div style={{ textAlign: 'center', marginTop: '150px' }}>
+      {/* <Circular large={60} small={60} /> */}
+      <p>ロード中</p>
+      </div>
+    );
+  }
 
   return(
     <>
+    {contentVideo.map((content_video) => (
       <div>
-          <h1>個別記事 {id}</h1>
+          <h1>個別記事 {content_video.attributes.id}</h1>
           <Card>
               <CardContent>
                 <Typography gutterBottom variant="h5" component="div">
-                  {title}
+                  {content_video.attributes.title}
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
                   Lizards are a widespread group of squamate reptiles, with over 6,000
                   species, ranging across all continents except Antarctica
                 </Typography>
               </CardContent>
-              <img src={`${process.env.PUBLIC_URL}/thumbnail/${youtube_url}`} width="100%" />
+              <img src={`${process.env.PUBLIC_URL}/thumbnail/${content_video.attributes.youtube_url}`} width="100%" />
           </Card>
       </div>
+      ))}
     </>
   )
 }
+
+export const ContentVideoShow= () => {
+  const queryClient = new QueryClient();
+  return (
+    // ProviderでQueryClientを設定する
+    <QueryClientProvider client={queryClient}>
+      <GetContentVideo />
+    </QueryClientProvider>
+  );
+};
+
 
 export default ContentVideoShow;

--- a/src/components/pages/ContentVideoShow.tsx
+++ b/src/components/pages/ContentVideoShow.tsx
@@ -9,6 +9,7 @@ import {
   QueryClientProvider,
   useQuery,
 } from 'react-query';
+import { ContentVideoShowCard } from "components/organisms/ContentVideoShowCard";
 import Card from "@material-ui/core/Card";
 import CardActions from '@mui/material/CardActions';
 import CardContent from '@mui/material/CardContent';
@@ -19,7 +20,7 @@ interface State {
   id: number;
 }
 
-const GetContentVideo = () => {
+const GetContentVideo = ({}) => {
   const [contentVideo, setContentVideo ] = useState<ContentVideo[]>([]);
   const location = useLocation();
   const { id } = location.state as State;
@@ -39,41 +40,37 @@ const GetContentVideo = () => {
         console.error(error.response.data);
       });
       setContentVideo(res.data.data);
+      console.log(res.data.data)
       console.log(contentVideo)
     }
   );
-
+  console.log(contentVideo)
   if (queryLoading) {
     return (
       <div style={{ textAlign: 'center', marginTop: '150px' }}>
       {/* <Circular large={60} small={60} /> */}
       <p>ロード中</p>
       </div>
-    );
+    )
   }
 
-  return(
-    <>
-    {contentVideo.map((content_video) => (
-      <div>
-          <h1>個別記事 {content_video.attributes.id}</h1>
-          <Card>
-              <CardContent>
-                <Typography gutterBottom variant="h5" component="div">
-                  {content_video.attributes.title}
-                </Typography>
-                <Typography variant="body2" color="text.secondary">
-                  Lizards are a widespread group of squamate reptiles, with over 6,000
-                  species, ranging across all continents except Antarctica
-                </Typography>
-              </CardContent>
-              <img src={`${process.env.PUBLIC_URL}/thumbnail/${content_video.attributes.youtube_url}`} width="100%" />
-          </Card>
-      </div>
-      ))}
-    </>
+
+  return (
+    <div className="container">
+      {/** query.isLoadingがtureのとき、つまり、ロード中はクラスネームのローダーのやつが表示*/}
+        <ContentVideoShowCard
+          id = {contentVideo.attributes.id}
+          number = {contentVideo.attributes.number}
+          title = {contentVideo.attributes.title}
+          description = {contentVideo.attributes.description}
+          youtube_url = {contentVideo.attributes.youtube_url}
+          //liked = {contentVideo.attributes.liked}
+        />
+    </div>
   )
 }
+
+
 
 export const ContentVideoShow= () => {
   const queryClient = new QueryClient();

--- a/src/types/contentvideo.ts
+++ b/src/types/contentvideo.ts
@@ -1,9 +1,9 @@
 export type ContentVideo = {
   id: number;
-  number: string;
-  title: string;
-  description: string;
-  youtube_url: string;
-  liked: boolean;
-  attributes: any;
+  number?: string;
+  title?: string;
+  description?: string;
+  youtube_url?: string;
+  liked?: boolean;
+  attributes?: any;
 };


### PR DESCRIPTION
【質問内容・実現したいこと】
「S3にアップロードされた動画のURLを、フロントエンドのreactに送りたい」
ユーザーの投稿動画と、こちらが用意した動画を結合して、その完成動画を視聴したいのですが、その方法論に詰まっており、
アドバイス頂けたら幸いです。

【現状】
reactからS3に投稿動画ダイレクトアップロード→
mediaconvertで元々用意しておいた動画と結合→
完成版動画を別のS3バケットにアップロード→
アップロードをトリガーとしてlambda関数を着火、DL用署名付URL発行

現在、ここまではできているのですが、
「どうやって、このURLをフロントエンドのReactに受け取らせるか」の方法に詰まっております。

【考えてみたアイディア】

①lambda関数を着火、DL用署名付URL発行→lambda上で、pythonの「requests」でrailsのHTTPリクエストをたたき、
dataでURLを送る。
→ただ、railsに送れたところで、フロントが受け取るためには、フロント側からのリクエストが必要なのでは、、？

②reactからS3に投稿動画ダイレクトアップロード→アップロード処理が成功したら、その流れで、完成版動画のS3バケットを対象に、完成版動画のURLを取得する処理を走らせる。（axiosの.thenを活用）
→投稿動画アップロードから完成版動画のアップロードの間、結合処理の時間が存在する。その時間中、リクエストを送り続けることって可能？？

ちょっと迷走気味になってしまいまして、ご相談できたら嬉しいです、、